### PR TITLE
Fix/#83 Remove Compression Middlware

### DIFF
--- a/Backend/app.js
+++ b/Backend/app.js
@@ -1,6 +1,5 @@
 var express = require('express');
 var path = require('path');
-var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
@@ -46,8 +45,6 @@ app.use(cookieParser());
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
 
-// uncomment after placing your favicon in /public
-//app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 if (!testMode) app.use(logger('dev'));
 app.use(bodyParser.json({limit: '4MB'}));
 app.use(bodyParser.urlencoded({ limit: '4MB', extended: false }));

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -5318,18 +5318,6 @@
         }
       }
     },
-    "serve-favicon": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",
-      "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
-      "requires": {
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "ms": "2.0.0",
-        "parseurl": "~1.3.2",
-        "safe-buffer": "5.1.1"
-      }
-    },
     "serve-static": {
       "version": "1.12.6",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -29,7 +29,6 @@
     "raven": "^2.6.2",
     "request": "^2.83.0",
     "sequelize": "^4.39.0",
-    "serve-favicon": "~2.4.5",
     "xml-js": "^1.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #83

This removes the compression middleware since that task is already handled by our nginx reverse proxy.

Also removes serve-favicon which was unneeded.