### PR TITLE
Deploy no longer overwrites old source hashes

### DIFF
--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -15,7 +15,7 @@ if [ $? -eq 0 ]; then
 
     rm deploy-prod.tgz
 
-    ssh julian@recipesage.com 'cd /var/www/recipesage.com; rm -rf ./*; tar -zxvf /tmp/deploy-prod.tgz; mv www/* .'
+    ssh julian@recipesage.com 'cd /var/www/recipesage.com; tar -zxvf /tmp/deploy-prod.tgz; rsync -av www/* .; rm -rf www'
 else
     echo FAIL
 fi


### PR DESCRIPTION
This fixes errors trying to lazyload pages.
Probably want to be on the lookout for conflicting files and stale (very
old) deploy files lingering. For now, this is a decent fix.