### PR TITLE
Revert "Squash image before push for smaller output"

### DIFF
--- a/scripts/deploy/push_api_docker.sh
+++ b/scripts/deploy/push_api_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 docker build --build-arg VERSION=$1 -f Backend/Dockerfile -t julianpoy/recipesage:api-latest -t rs-api-builder .
-docker build --build-arg VERSION=$1 -f Backend/pkg.Dockerfile -t julianpoy/recipesage-selfhost:api-latest --squash .
+docker build --build-arg VERSION=$1 -f Backend/pkg.Dockerfile -t julianpoy/recipesage-selfhost:api-latest .
 
 docker push julianpoy/recipesage:api-latest
 docker push julianpoy/recipesage-selfhost:api-latest


### PR DESCRIPTION
Would prefer to have a larger image just so that we can maintain all layers + history for easier reuse and modification.

This reverts the addition of --squash for the selfhost image.