### PR TITLE
Add rel="noreferrer noopener" to recipe source links

### DIFF
--- a/Frontend/src/app/components/social-links/social-links.component.html
+++ b/Frontend/src/app/components/social-links/social-links.component.html
@@ -1,24 +1,24 @@
 <ion-item lines="none" href="https://facebook.com/recipesageofficial" target="_blank">
   <ion-icon slot="start" name="logo-facebook"></ion-icon>
   <ion-label>
-    <p><a target="_blank" href="https://facebook.com/recipesageofficial">Facebook</a></p>
+    <p><a href="https://facebook.com/recipesageofficial" target="_blank" rel="noreferrer noopener">Facebook</a></p>
   </ion-label>
 </ion-item>
 <ion-item lines="none" href="https://twitter.com/recipesageo" target="_blank">
   <ion-icon slot="start" name="logo-twitter"></ion-icon>
   <ion-label>
-    <p><a target="_blank" href="https://twitter.com/recipesageo">Twitter</a></p>
+    <p><a href="https://twitter.com/recipesageo" target="_blank" rel="noreferrer noopener">Twitter</a></p>
   </ion-label>
 </ion-item>
 <ion-item lines="none" href="https://instagram.com/recipesageofficial" target="_blank">
   <ion-icon slot="start" name="logo-instagram"></ion-icon>
   <ion-label>
-    <p><a target="_blank" href="https://instagram.com/recipesageofficial">Instagram</a></p>
+    <p><a href="https://instagram.com/recipesageofficial" target="_blank" rel="noreferrer noopener">Instagram</a></p>
   </ion-label>
 </ion-item>
 <ion-item lines="none" href="https://discord.gg/yCfzBft" target="_blank">
   <ion-icon slot="start" name="chatbox-ellipses"></ion-icon>
   <ion-label>
-    <p><a target="_blank" href="https://discord.gg/yCfzBft">Discord</a></p>
+    <p><a href="https://discord.gg/yCfzBft" target="_blank" rel="noreferrer noopener">Discord</a></p>
   </ion-label>
 </ion-item>

--- a/Frontend/src/app/pages/auth/auth.page.html
+++ b/Frontend/src/app/pages/auth/auth.page.html
@@ -17,7 +17,7 @@
         <br /><br />
 
         <div *ngIf="isSelfHost">
-          Note: This is a selfhosted version of RecipeSage and is therefore not associated with <a href="https://recipesage.com">RecipeSage.com</a> or any of the accounts located on the main site.
+          Note: This is a selfhosted version of RecipeSage and is therefore not associated with <a href="https://recipesage.com" target="_blank" rel="noreferrer noopener">RecipeSage.com</a> or any of the accounts located on the main site.
         </div>
 
         <br /><br />

--- a/Frontend/src/app/pages/home/home.page.html
+++ b/Frontend/src/app/pages/home/home.page.html
@@ -153,9 +153,9 @@
           <br /><br />
 
           For desktop browsers, you can use our<br />
-          <a href="https://chrome.google.com/webstore/detail/oepplnnfceidfaaacjpdpobnjkcpgcpo" target="_blank">Chrome</a>
+          <a href="https://chrome.google.com/webstore/detail/oepplnnfceidfaaacjpdpobnjkcpgcpo" target="_blank" rel="noreferrer noopener">Chrome</a>
           &
-          <a href="https://addons.mozilla.org/en-US/firefox/addon/recipesage/" target="_blank">Firefox</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/recipesage/" target="_blank" rel="noreferrer noopener">Firefox</a>
           extensions to clip recipes from the web<br />
 
           <br /><br />

--- a/Frontend/src/app/pages/info-components/about-details/about-details.page.html
+++ b/Frontend/src/app/pages/info-components/about-details/about-details.page.html
@@ -32,8 +32,8 @@
   <br />
   <p><b>Links</b></p>
   <p>Feel free to shoot me an email at <a href="mailto:julian@recipesage.com?subject=RecipeSage Support">julian@recipesage.com</a></p>
-  <p>My Github profile is <a target="_blank" href="https://github.com/julianpoy">julianpoy</a></p>
-  <p>My personal website is <a target="_blank" href="https://julianpoyourow.com">julianpoyourow.com</a></p>
+  <p>My Github profile is <a href="https://github.com/julianpoy" target="_blank" rel="noreferrer noopener">julianpoy</a></p>
+  <p>My personal website is <a href="https://julianpoyourow.com" target="_blank" rel="noreferrer noopener">julianpoyourow.com</a></p>
 
   <br />
   <p><b>Social Media</b></p>

--- a/Frontend/src/app/pages/info-components/contact/contact.page.html
+++ b/Frontend/src/app/pages/info-components/contact/contact.page.html
@@ -15,7 +15,7 @@
   <p><b>Contact Info</b></p>
 
   <p>Feel free to shoot me an email at <a href="mailto:julian@recipesage.com?subject=RecipeSage Support">julian@recipesage.com</a></p>
-  <p>My personal website is <a target="_blank" href="https://julianpoyourow.com">julianpoyourow.com</a></p>
+  <p>My personal website is <a href="https://julianpoyourow.com" target="_blank" rel="noreferrer noopener">julianpoyourow.com</a></p>
 
   <br />
   <p><b>Social Media</b></p>

--- a/Frontend/src/app/pages/info-components/legal/legal.page.html
+++ b/Frontend/src/app/pages/info-components/legal/legal.page.html
@@ -15,9 +15,9 @@
   <div *ngIf="isSelfHost">
     <h1>Note: Some parts of this page apply to software hosted at RecipeSage.com.</h1>
     Keep in mind that all RecipeSage images, branding, naming, code, etc. are not licensed for commercial or non-personal use. If you would like to use RecipeSage or any of it's associated materials for commercial or non-personal use, please feel free to contact me.<br />
-    You can also self host your own personal, non-commercial copy based on the configurations provided at <a href="https://github.com/julianpoy/recipesage-selfhosted">https://github.com/julianpoy/recipesage-selfhosted</a>
+    You can also self host your own personal, non-commercial copy based on the configurations provided at <a href="https://github.com/julianpoy/recipesage-selfhosted" target="_blank" rel="noreferrer noopener">https://github.com/julianpoy/recipesage-selfhosted</a>
     Again, this is a self hosted version of the site, so RecipeSage official may not be able to back some of the commitments below in regards to the self hosted version. RecipeSage expects that all self hosted instances follow the guidelines below, but RecipeSage cannot be held responsible for self hosted versions.<br />
-    Additionally, all terms from the self host license at <a href="https://github.com/julianpoy/recipesage-selfhosted">https://github.com/julianpoy/recipesage-selfhosted</a> apply to users &amp; self host server owners.
+    Additionally, all terms from the self host license at <a href="https://github.com/julianpoy/recipesage-selfhosted" target="_blank" rel="noreferrer noopener">https://github.com/julianpoy/recipesage-selfhosted</a> apply to users &amp; self host server owners.
     <br />
     <br />
     <br />

--- a/Frontend/src/app/pages/info-components/tips-tricks-tutorials/tips-tricks-tutorials.page.html
+++ b/Frontend/src/app/pages/info-components/tips-tricks-tutorials/tips-tricks-tutorials.page.html
@@ -437,8 +437,8 @@
         into your collection.<br /><br />
         To install the RecipeSage browser extension, you'll need to be using a browser that supports WebExtensions.<br />
         At the time of writing, this includes Firefox and Google Chrome.<br /><br />
-        If you're using Google Chrome, <a href="https://chrome.google.com/webstore/detail/oepplnnfceidfaaacjpdpobnjkcpgcpo" target="_blank">click here</a><br />
-        If you're using Firefox, <a href="https://addons.mozilla.org/en-US/firefox/addon/recipesage/" target="_blank">click here</a>
+        If you're using Google Chrome, <a href="https://chrome.google.com/webstore/detail/oepplnnfceidfaaacjpdpobnjkcpgcpo" target="_blank" rel="noreferrer noopener">click here</a><br />
+        If you're using Firefox, <a href="https://addons.mozilla.org/en-US/firefox/addon/recipesage/" target="_blank" rel="noreferrer noopener">click here</a>
       </p>
 
       <br />
@@ -533,17 +533,17 @@
       <p>
         <b>Q: Can I selfhost my own instance of RecipeSage?</b><br />
         Yes, for personal, private, non-commercial use only. You can find all of the resources to do that here:<br />
-        <a href="https://github.com/julianpoy/recipesage-selfhost" target="_blank">RecipeSage Self Host Repository</a><br />
+        <a href="https://github.com/julianpoy/recipesage-selfhost" target="_blank" rel="noreferrer noopener">RecipeSage Self Host Repository</a><br />
       </p>
 
       <p>
         <b>Q: Is RecipeSage Open Source?</b><br />
         Yes! Here are some of the repositories that host the components that power RecipeSage:<br /><br />
 
-        - <a href="https://github.com/julianpoy/recipesage" target="_blank">The main RecipeSage repository</a><br />
-        - <a href="https://github.com/julianpoy/recipesage-selfhost" target="_blank">A collection of docker files for running your own personal/private copy of RecipeSage</a><br />
-        - <a href="https://github.com/julianpoy/recipeclipper" target="_blank">The recipe clipper for the automatic recipe clipping function</a><br />
-        - <a href="https://github.com/julianpoy/ingredient-instruction-classifier" target="_blank">The ingredient/instruction classifier that improves automatic recipe import results</a><br />
+        - <a href="https://github.com/julianpoy/recipesage" target="_blank" rel="noreferrer noopener">The main RecipeSage repository</a><br />
+        - <a href="https://github.com/julianpoy/recipesage-selfhost" target="_blank" rel="noreferrer noopener">A collection of docker files for running your own personal/private copy of RecipeSage</a><br />
+        - <a href="https://github.com/julianpoy/recipeclipper" target="_blank" rel="noreferrer noopener">The recipe clipper for the automatic recipe clipping function</a><br />
+        - <a href="https://github.com/julianpoy/ingredient-instruction-classifier" target="_blank" rel="noreferrer noopener">The ingredient/instruction classifier that improves automatic recipe import results</a><br />
 
         <br />
         Check out the <a href="/#/about/contact">Discord server</a> for more info!<br />

--- a/Frontend/src/app/pages/info-components/welcome/welcome.page.html
+++ b/Frontend/src/app/pages/info-components/welcome/welcome.page.html
@@ -29,7 +29,7 @@
       </h1>
 
       <p class="subtitle" *ngIf="isSelfHost">
-        An unofficial selfhosted version of <a href="https://recipesage.com">RecipeSage</a>, a free (open source) recipe keeper, meal planner, and shopping list organizer for Web, IOS, and Android
+        An unofficial selfhosted version of <a href="https://recipesage.com" target="_blank" rel="noreferrer noopener">RecipeSage</a>, a free (open source) recipe keeper, meal planner, and shopping list organizer for Web, IOS, and Android
       </p>
 
       <p class="subtitle" *ngIf="!isSelfHost">

--- a/Frontend/src/app/pages/recipe-components/recipe/recipe.page.html
+++ b/Frontend/src/app/pages/recipe-components/recipe/recipe.page.html
@@ -34,7 +34,7 @@
             <ion-col *ngIf="recipe.source || recipe.url" class="ion-no-padding" size="auto">
               <p class="ion-text-wrap">
                 <b>Source: </b>
-                <a *ngIf='recipe.url?.trim()' href="{{ recipe.url ? recipe.url : '' }}" target="_blank">{{ recipe.source?.trim() || recipe.url }}</a>
+                <a *ngIf='recipe.url?.trim()' href="{{ recipe.url ? recipe.url : '' }}" target="_blank" rel="noreferrer noopener">{{ recipe.source?.trim() || recipe.url }}</a>
                 <span *ngIf='!recipe.url?.trim()'>{{ recipe.source?.trim() }}</span>
               </p>
             </ion-col>
@@ -59,7 +59,7 @@
           <ion-col *ngIf="recipe.source || recipe.url" class="ion-no-padding" size="auto">
             <p>
               <b>Source: </b>
-              <a *ngIf='recipe.url?.trim()' href="{{ recipe.url ? recipe.url : '' }}" target="_blank">{{ recipe.source?.trim() || recipe.url }}</a>
+              <a *ngIf='recipe.url?.trim()' href="{{ recipe.url ? recipe.url : '' }}" target="_blank" rel="noreferrer noopener">{{ recipe.source?.trim() || recipe.url }}</a>
               <span *ngIf='!recipe.url?.trim()'>{{ recipe.source?.trim() }}</span>
             </p>
           </ion-col>

--- a/Frontend/src/app/pages/settings-components/import-livingcookbook/import-livingcookbook.page.html
+++ b/Frontend/src/app/pages/settings-components/import-livingcookbook/import-livingcookbook.page.html
@@ -125,7 +125,7 @@
           <br />
           <p>
             If your database is too large: <br />
-            Upload your database to Firefox Send (<a href="https://send.firefox.com" target="_blank">https://send.firefox.com</a>)
+            Upload your database to Firefox Send (<a href="https://send.firefox.com" target="_blank" rel="noreferrer noopener">https://send.firefox.com</a>)
             and email me the link it gives you at the end.
           </p>
           <br />


### PR DESCRIPTION
Adding rel="noopener" is a sensible idea for any external links. Adding
rel="noreferrer" also makes a lot of sense for self-hostable FOSS
software, because it's entirely reasonable that people may not want
their private domain names leaking out over the internet.