### PR TITLE
Grid display of recipes instead of flexbox

### DIFF
--- a/Frontend/src/app/pages/home/home.page.scss
+++ b/Frontend/src/app/pages/home/home.page.scss
@@ -26,9 +26,10 @@
 }
 
 .card-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-around;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 200px);
+  grid-gap: 20px;
+  padding-right: 20px;
 
   ion-card {
     width: 200px;


### PR DESCRIPTION
I changed the current `display` property value from `flex` to `grid` on the recipe cards container.  

This enables to align recipe cards both horizontally and vertically.   

I find this more friendly. Here are some screenshots to see the result :  

**Before :**   
![image](https://user-images.githubusercontent.com/57016732/131232707-a21278a9-1268-44e2-9d12-3e7e45941bd5.png)

**Now :**   
![image](https://user-images.githubusercontent.com/57016732/131232934-9f97fb2b-c39d-4e02-80e9-c1d0dccc72a8.png)


As it was with flexbox, the recipes displaying is still responsive, as you can see in the following video:  
https://streamable.com/r73wjd

Spaces between the cards can easilly be changed thanks to the `grid-gap` property.