### PR TITLE
Add PWA as a share target

### DIFF
--- a/Frontend/src/app/pages/recipe-components/edit-recipe/edit-recipe.page.ts
+++ b/Frontend/src/app/pages/recipe-components/edit-recipe/edit-recipe.page.ts
@@ -45,6 +45,22 @@ export class EditRecipePage {
 
     const recipeId = this.route.snapshot.paramMap.get('recipeId');
 
+    if (recipeId === 'new') {
+      // Check if we're passing parameters to new, if so, attempt to automatically import the given recipe
+      let url = this.route.snapshot.queryParamMap.get('url');
+      let text = this.route.snapshot.queryParamMap.get('text');
+      let title = this.route.snapshot.queryParamMap.get('title');
+      if ( this.findLastUrlInString(url) != null ) {
+        this._clipFromUrl(this.findLastUrlInString(url));
+      }
+      else if ( this.findLastUrlInString(text) != null ) {
+        this._clipFromUrl(this.findLastUrlInString(text));
+      }
+      else if ( this.findLastUrlInString(title) != null ) {
+        this._clipFromUrl(this.findLastUrlInString(title));
+      }
+    }
+
     if (recipeId !== 'new') {
       this.recipeId = recipeId;
 
@@ -89,6 +105,16 @@ export class EditRecipePage {
 
   goToAuth(cb?: () => any) {
     // TODO: Needs functionality
+  }
+
+  findLastUrlInString(s) {
+    if ( typeof(s) != "string" ) { return; }
+
+    // Robust URL finding regex from https://www.regextester.com/93652
+    let matchedUrl = s.match(/(?:(?:https?|ftp):\/\/|\b(?:[a-z\d]+\.))(?:(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))?\))+(?:\((?:[^\s()<>]+|(?:\(?:[^\s()<>]+\)))?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))?/gi);
+    if ( matchedUrl !== null ) {
+      return matchedUrl[matchedUrl.length - 1];
+    }
   }
 
   async save() {

--- a/Frontend/src/app/services/default-page-guard.service.ts
+++ b/Frontend/src/app/services/default-page-guard.service.ts
@@ -9,8 +9,13 @@ export class DefaultPageGuardService {
 
   canActivate() {
     const isLoggedIn = this.utilService.isLoggedIn();
+    const fullURL = new URL(window.location.href);
+    const isShareTarget = fullURL.pathname === "/shareTarget";
 
-    if (isLoggedIn) this.navCtrl.navigateRoot(RouteMap.HomePage.getPath('main'));
+    if (isLoggedIn) {
+      if (isShareTarget) this.navCtrl.navigateRoot(RouteMap.EditRecipePage.getPath('new') + '?' + fullURL.searchParams.toString());
+      else this.navCtrl.navigateRoot(RouteMap.HomePage.getPath('main'));
+    }
     else this.navCtrl.navigateRoot(RouteMap.WelcomePage.getPath());
 
     return false;

--- a/Frontend/src/manifest.json
+++ b/Frontend/src/manifest.json
@@ -37,6 +37,15 @@
       "url": "/#/meal-planners?utm_source=homescreen"
     }
   ],
+  "share_target": {
+      "action": "/shareTarget",
+      "method": "GET",
+      "params": {
+        "title": "title",
+        "text": "text",
+        "url": "url"
+    }
+  },
   "background_color": "#353b48",
   "theme_color": "#353b48",
   "gcm_sender_id": "103953800507"


### PR DESCRIPTION
Progressive Webapps can be registered as share targets, so when you press "share" from any other application you will now be able to select RecipeSage as an option.
This will automatically take you to the "New Recipe" screen, and begin importing the shared URL.

You will need to reinstall RecipeSage in order to get this update.

Some implementation notes:
* The way applications pass the URL info to a share target is different across apps/platforms (can be a random part of text, or in title, etc). Hence using regex to search all the passed parameters.
* PWA share targets can only receive `url`, `text`, and `title` parameters. Hence using a `fullpath` check instead of another query parameter.
* Angular is not aware of the full URL due to the HashLocation strategy. Hence using `window.location.href` inside of the Angular app.