### PR TITLE
chore: stop push for merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
-              only: /^master$/
+              ignore: /.*/
       - push_frontend:
           requires:
             - build_test_frontend
@@ -187,5 +187,5 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*.*/
             branches:
-              only: /^master$/
+              ignore: /.*/
 


### PR DESCRIPTION
Just takes build minutes at the moment, and not really using for anything. Would like to re-enable later for a better staging env.