### PR TITLE
fix: old browser support

### DIFF
--- a/Frontend/tsconfig.json
+++ b/Frontend/tsconfig.json
@@ -11,7 +11,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,
-    "target": "es6",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
I recall having an issue with ES5 support related to a dependency (see #821 and #822).

Unfortunately bumping to ES6 support has broken some support in older browsers. Will trial moving back to an ES5 target and see what breaks.