### PR TITLE
fix: selfhosting image path on export

### DIFF
--- a/packages/backend/src/routes/data.js
+++ b/packages/backend/src/routes/data.js
@@ -94,7 +94,7 @@ const getRecipeDataForExport = async userId => {
         }
 
         if (location.startsWith('/')) {
-          const data = fs.readFileSync(location);
+          const data = fs.readFileSync(location.replace('/api/images/filesystem', '/rs-media'));
           const base64 = data.toString('base64');
 
           image.location = `data:image/png;base64,${base64}`;

--- a/packages/backend/src/routes/data.js
+++ b/packages/backend/src/routes/data.js
@@ -94,7 +94,7 @@ const getRecipeDataForExport = async userId => {
         }
 
         if (location.startsWith('/')) {
-          const data = fs.readFileSync(location.replace('/api/images/filesystem', '/rs-media'));
+          const data = fs.readFileSync(location.replace('/api/images/filesystem', process.env.FILESYSTEM_STORAGE_PATH));
           const base64 = data.toString('base64');
 
           image.location = `data:image/png;base64,${base64}`;


### PR DESCRIPTION
Exporting recipes on selfhosted instances attempts to read a recipe image using the full path `/api/images/filesystem/recipeImage/<image-id>` . This PR updates that path so the backend reads from `/rs-media/recipeImage/<image-id>`, and the image can be read using readFileSync

Bug was tested and fixed using v2.11.0-beta18