### PR TITLE
fix: update side menu language immediately

### DIFF
--- a/packages/frontend/src/app/app.component.html
+++ b/packages/frontend/src/app/app.component.html
@@ -6,7 +6,11 @@
     [disabled]="!isLoggedIn || !preferences[preferenceKeys.EnableSplitPane]"
     when="(min-width: 1200px)"
   >
-    <ion-menu contentId="main-content" type="overlay">
+    <ion-menu
+      (ionWillOpen)="updateNavList()"
+      contentId="main-content"
+      type="overlay"
+    >
       <ion-header>
         <ion-toolbar color="nav">
           <ion-title


### PR DESCRIPTION
The side menu did not update language immediately and required a navigation event to reflect the user's new chosen language.

The nav now updates immediately.