### PR TITLE
fix: disable sentry completely for selfhost

### DIFF
--- a/packages/frontend/src/app/app.module.ts
+++ b/packages/frontend/src/app/app.module.ts
@@ -18,7 +18,11 @@ import { UnsavedChangesGuardService } from "./services/unsaved-changes-guard.ser
 
 import { CookingToolbarModule } from "./components/cooking-toolbar/cooking-toolbar.module";
 
-import { environment, SENTRY_SAMPLE_RATE } from "../environments/environment";
+import {
+  environment,
+  IS_SELFHOST,
+  SENTRY_SAMPLE_RATE,
+} from "../environments/environment";
 import { SupportedLanguages } from "./services/preferences.service";
 
 const checkChunkLoadError = (error: Error) => {
@@ -55,18 +59,20 @@ console.error = (...args) => {
   origConsoleError.apply(console, args);
 };
 
-Sentry.init({
-  release: (window as any).version,
-  environment: environment.production ? "production" : "dev",
-  dsn: "https://056d11b20e624d52a5771ac8508dd0b8@sentry.io/1219200",
-  tracesSampleRate: SENTRY_SAMPLE_RATE,
-  beforeSend(event, hint) {
-    const error = hint.originalException as Error;
-    if (checkChunkLoadError(error)) return null;
-    if (checkSupressedError(error)) return null;
-    return event;
-  },
-});
+if (!IS_SELFHOST) {
+  Sentry.init({
+    release: (window as any).version,
+    environment: environment.production ? "production" : "dev",
+    dsn: "https://056d11b20e624d52a5771ac8508dd0b8@sentry.io/1219200",
+    tracesSampleRate: SENTRY_SAMPLE_RATE,
+    beforeSend(event, hint) {
+      const error = hint.originalException as Error;
+      if (checkChunkLoadError(error)) return null;
+      if (checkSupressedError(error)) return null;
+      return event;
+    },
+  });
+}
 
 export function createTranslateLoader(http: HttpClient) {
   const prefix = "assets/i18n/";


### PR DESCRIPTION
Sentry was already reporting at 0% so no data has been collected so far, but this further removes Sentry by not initializing it at all in the first place. A user had noticed that it does hit the Sentry servers in some cases, though is denied server-side by Sentry in that case.