### PR TITLE
fix: disable animations in firefox

### DIFF
--- a/packages/frontend/src/app/app.component.html
+++ b/packages/frontend/src/app/app.component.html
@@ -53,6 +53,7 @@
     </ion-menu>
     <ion-router-outlet
       id="main-content"
+      [animated]="enableAnimations"
       [class]="{
         cookingToolbarOpen: cookingToolbarService.pinnedRecipes.length > 0
       }"

--- a/packages/frontend/src/app/app.component.ts
+++ b/packages/frontend/src/app/app.component.ts
@@ -44,6 +44,9 @@ export class AppComponent {
   isSelfHost = IS_SELFHOST;
   isLoggedIn?: boolean;
 
+  // See https://bugzilla.mozilla.org/show_bug.cgi?id=1811099
+  enableAnimations = !navigator.userAgent.toLowerCase().includes("firefox");
+
   navList?: { id: string; title: string; icon: string; url: string }[];
 
   inboxCount?: number;


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1811099

(linked from https://github.com/ionic-team/ionic-framework/issues/26620)