### PR TITLE
fix: user feedback messages and seenTutorial flag for webextension-v3 

### DIFF
--- a/packages/webextension-v3/src/action/action.html
+++ b/packages/webextension-v3/src/action/action.html
@@ -72,7 +72,8 @@
       }
 
       #message {
-        color: red;
+        display: inline-block;
+        padding-top: 10px;
       }
 
       .headline {

--- a/packages/webextension-v3/src/action/action.html
+++ b/packages/webextension-v3/src/action/action.html
@@ -71,6 +71,10 @@
         display: none;
       }
 
+      #message {
+        color: red;
+      }
+
       .headline {
         text-align: center;
       }
@@ -92,18 +96,15 @@
           <img class="logo" /><br /><br />
           <h2>Import Site</h2>
         </div>
-        <span id="message">
-          <button id="auto-import">&nbsp;Auto Import&nbsp;</button>&nbsp;
-          <button id="interactive-import">&nbsp;Interactive Import&nbsp;</button
-          >&nbsp;
-        </span>
+        <button id="auto-import">&nbsp;Auto Import&nbsp;</button>&nbsp;
+        <button id="interactive-import">&nbsp;Interactive Import&nbsp;</button
+        >&nbsp;
       </div>
       <div id="importing">
         <div class="headline">
           <img class="logo" /><br /><br />
           <h2>Importing, please wait...</h2>
         </div>
-        <span id="message">This can take a minute.</span>
       </div>
       <div id="login">
         <div class="headline">
@@ -125,7 +126,6 @@
         <a href="https://recipesage.com/#/auth/register" target="_blank"
           >Create an account</a
         >
-        <span id="message"></span>
       </div>
       <div id="tutorial">
         <div class="headline">
@@ -161,6 +161,7 @@
         <br />
         <button id="tutorial-submit">Dismiss</button>
       </div>
+      <span id="message"></span>
     </div>
   </body>
 </html>

--- a/packages/webextension-v3/src/action/action.js
+++ b/packages/webextension-v3/src/action/action.js
@@ -29,11 +29,11 @@ const login = async () => {
       switch (loginResponse.status) {
         case 412:
           document.getElementById("message").innerText =
-            "\nIt looks like that email or password isn't correct.";
+            "It looks like that email or password isn't correct.";
           break;
         default:
           document.getElementById("message").innerText =
-            "\nSomething went wrong. Please try again.";
+            "Something went wrong. Please try again.";
           break;
       }
       return;
@@ -45,10 +45,8 @@ const login = async () => {
     chrome.storage.local.set({ token }, () => {
       chrome.storage.local.get(["seenTutorial"], (result) => {
         if (result.seenTutorial) {
-          let message = document.getElementById("message");
-          message.style.color = "green";
-          message.innerText =
-            "\nYou are now logged in. Click the RecipeSage icon again to clip\
+          document.getElementById("message").innerText =
+            "You are now logged in. Click the RecipeSage icon again to clip\
              this website.";
           setTimeout(() => {
             window.close();

--- a/packages/webextension-v3/src/action/action.js
+++ b/packages/webextension-v3/src/action/action.js
@@ -68,6 +68,7 @@ const showTutorial = () => {
   document.getElementById("tutorial").style.display = "block";
   document.getElementById("importing").style.display = "none";
   document.getElementById("start").style.display = "none";
+  chrome.storage.local.set({ seenTutorial: true });
 };
 
 const showLoading = () => {

--- a/packages/webextension-v3/src/action/action.js
+++ b/packages/webextension-v3/src/action/action.js
@@ -29,11 +29,11 @@ const login = async () => {
       switch (loginResponse.status) {
         case 412:
           document.getElementById("message").innerText =
-            "It looks like that email or password isn't correct.";
+            "\nIt looks like that email or password isn't correct.";
           break;
         default:
           document.getElementById("message").innerText =
-            "Something went wrong. Please try again.";
+            "\nSomething went wrong. Please try again.";
           break;
       }
       return;
@@ -45,11 +45,13 @@ const login = async () => {
     chrome.storage.local.set({ token }, () => {
       chrome.storage.local.get(["seenTutorial"], (result) => {
         if (result.seenTutorial) {
-          document.getElementById("message").innerText =
-            "You are now logged in. Click the RecipeSage icon again to clip this website.";
+          let message = document.getElementById("message");
+          message.style.color = "green";
+          message.innerText =
+            "\nYou are now logged in. Click the RecipeSage icon again to clip this website.";
           setTimeout(() => {
             window.close();
-          }, 2000);
+          }, 5000);
         } else {
           showTutorial();
         }

--- a/packages/webextension-v3/src/action/action.js
+++ b/packages/webextension-v3/src/action/action.js
@@ -48,7 +48,8 @@ const login = async () => {
           let message = document.getElementById("message");
           message.style.color = "green";
           message.innerText =
-            "\nYou are now logged in. Click the RecipeSage icon again to clip this website.";
+            "\nYou are now logged in. Click the RecipeSage icon again to clip\
+             this website.";
           setTimeout(() => {
             window.close();
           }, 5000);
@@ -59,7 +60,8 @@ const login = async () => {
     });
   } catch (e) {
     document.getElementById("message").innerText =
-      "Something went wrong. Please check your internet connection and try again.";
+      "Something went wrong. Please check your internet connection and try\
+       again.";
   }
 };
 
@@ -209,13 +211,15 @@ const saveClip = async (clipData) => {
       case 401:
         chrome.storage.local.set({ token: null }, () => {
           window.alert(
-            "Please Login. It looks like you're logged out. Please click the RecipeSage icon to login again.",
+            "Please Login. It looks like you're logged out. Please click the\
+             RecipeSage icon to login again.",
           );
         });
         break;
       default:
         window.alert(
-          "Could Not Save Recipe. An error occurred while saving the recipe. Please try again.",
+          "Could Not Save Recipe. An error occurred while saving the recipe.\
+           Please try again.",
         );
         break;
     }


### PR DESCRIPTION
User feedback messages (e.g. "Email/Password incorrect", "Something went wrong") were not displaying correctly, as there were multiple elements with `id="message"` in action.html. `document.getElementById("message")` was always selecting first occurrence under the `#start` div, but this div was hidden when the currently implemented messages were inserted. 

Fix moves the `#message` span to a single occurrence at the end of the primary container. I also added a localstorage variable setter to the `showTutorial()` function, as there was no setter implemented for the `seenTutorial` flag being evaluated upon a successful login and token save. Finally, window timeout upon successful token save increased to give user more time to read the success message. 

Submitting this PR in preparation for another PR adding custom/selfhosted server support to the webextension (v3). I wanted to see your preferences on the message implementation first, as there will be a need for additional feedback messages with custom server support. If you would prefer one PR for these message fixes and the custom server support, please let me know and I'll just merge the two. Thanks!
