### PR TITLE
fix: unlock orientation

### DIFF
--- a/packages/frontend/src/manifest.json
+++ b/packages/frontend/src/manifest.json
@@ -87,6 +87,5 @@
   "handle_links": "preferred",
   "launch_handler": {
     "client_mode": "navigate-existing"
-  },
-  "orientation": "portrait-primary"
+  }
 }


### PR DESCRIPTION
Closes #1239

This was added as a recommendation by PWABuilder. Unfortunately I believe I mistook the property description to mean that portrait-primary specified the preferred orientation. Apparently it actually locks the orientation to portrait...