### PR TITLE
fix(l10n): translations update from weblate.recipesage.com

### DIFF
--- a/packages/frontend/src/assets/i18n/da-dk.json
+++ b/packages/frontend/src/assets/i18n/da-dk.json
@@ -499,5 +499,8 @@
     "pages.editRecipe.save": "Gem",
     "pages.editRecipe.create": "Opret",
     "pages.editRecipe.clip.placeholder": "Opskrift-URL",
-    "pages.editRecipe.clip.invalidUrl": "Fejl: Du skal angive en gyldig URL"
+    "pages.editRecipe.clip.invalidUrl": "Fejl: Du skal angive en gyldig URL",
+    "pages.editRecipe.addImage.header": "Tilføj billede via URL",
+    "pages.editRecipe.addImage.message": "Indtast en billed-URL, der skal føjes til opskriften",
+    "pages.editRecipe.addImage.placeholder": "Billed-URL"
 }


### PR DESCRIPTION
Translations update from [RecipeSage Weblate](http://weblate.recipesage.com) for [RecipeSage App/Frontend UI](http://weblate.recipesage.com/projects/recipesage-app/app-frontend/).



Current translation status:

![Weblate translation status](http://weblate.recipesage.com/widget/recipesage-app/app-frontend/horizontal-auto.svg)