### PR TITLE
Add `or` as separator

### DIFF
--- a/packages/util/shared/src/parsers.ts
+++ b/packages/util/shared/src/parsers.ts
@@ -45,7 +45,7 @@ const replaceFractionsInText = (rawText: string): string => {
 // Starts with [, anything inbetween, ends with ]
 const headerRegexp = /^\[.*\]$/;
 
-const multipartQuantifierRegexp = / \+ | plus /;
+const multipartQuantifierRegexp = / \+ | plus | or /;
 
 const measurementRegexp =
   /((\d+ )?\d+([/.]\d+)?((-)|( to )|( - ))(\d+ )?\d+([/.]\d+)?)|((\d+ )?\d+[/.]\d+)|\d+/;


### PR DESCRIPTION
Add `or` as a supported separator in the ingredients list for strings like `2 Tbsp. Diamond Crystal or 1 Tbsp. plus 1/2 tsp. Morton kosher salt, divided; plus more`