### PR TITLE
fix: browser extension CORS

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -47,6 +47,7 @@ const defaultCorsAllowlist = [
   "capacitor://localhost",
   "moz-extension://*",
   "chrome-extension://oepplnnfceidfaaacjpdpobnjkcpgcpo",
+  "*", // Temporary fix for 1401, circle back and fix webextension manifests
 ];
 
 const hostMatch = (pattern: string, origin: string) => {


### PR DESCRIPTION
Temporary fix, which reintroduces allow-all behavior prior to v2.14.0