### PR TITLE
Add queso fresco to the dairy category

### DIFF
--- a/packages/backend/src/constants/itemCategories.json
+++ b/packages/backend/src/constants/itemCategories.json
@@ -480,6 +480,7 @@
   "pumpkin": "produce",
   "pumpkin puree": "grocery",
   "pumpkin seed": "grocery",
+  "*queso fresco": "dairy",
   "racks lamb": "meat",
   "radicchio": "produce",
   "radish": "produce",


### PR DESCRIPTION
Queso fresco gets erroneously categorized as liquor. 
It is a white cheese and should be categorized as dairy.
<img width="473" alt="Screenshot 2024-07-21 at 11 14 23 AM" src="https://github.com/user-attachments/assets/e924102a-0f4b-469b-973a-325867e3f302">
