### PR TITLE
Update nginx config and docker compose port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "80:80"
+      - "8080:80"
     command: nginx -g 'daemon off;'
     depends_on:
       - frontend

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,9 +5,9 @@ server {
 
 	  server_name localhost;
 
-    location /grip/ws {
-        resolver 127.0.0.11 valid=30s;
+    resolver 10.89.8.1 valid=30s;
 
+    location /grip/ws {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -18,12 +18,10 @@ server {
     }
 
     location /api/ {
-        resolver 127.0.0.11 valid=30s;
         proxy_pass http://backend:3000/;
     }
 
     location /app/ {
-        resolver 127.0.0.11 valid=30s;
         proxy_pass http://frontend:8100/app/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -31,17 +29,14 @@ server {
     }
 
     location = /service-worker.js {
-        resolver 127.0.0.11 valid=30s;
         proxy_pass http://frontend:8100/app/service-worker.js;
     }
 
     location = /manifest.json {
-        resolver 127.0.0.11 valid=30s;
         proxy_pass http://frontend:8100/app/manifest.json;
     }
 
 	  location / {
-        resolver 127.0.0.11 valid=30s;
         proxy_pass http://www:4321;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
- Change nginx resolver from Docker DNS to static IP 10.89.8.1
- Remove redundant resolver directives from individual locations
- Update docker-compose.yml to expose port 8080 instead of 80

Generated by Mistral Vibe.