### PR TITLE
fix: share target logged in redirect

### DIFF
--- a/packages/www/src/components/RootLayout.astro
+++ b/packages/www/src/components/RootLayout.astro
@@ -147,6 +147,16 @@ const finalStructuredData = structuredData ?? defaultStructuredData;
           return;
         }
         if (!redirectLoggedIn) return;
+        // Don't clobber an incoming Web Share Target request: index.astro
+        // redirects share params to /app/edit-recipe/new; skip the logged-in
+        // redirect so that destination is preserved instead of going to /app/.
+        const shareParams = new URLSearchParams(location.search);
+        if (
+          shareParams.has("sharetarget-title") ||
+          shareParams.has("sharetarget-text") ||
+          shareParams.has("autofill-url")
+        )
+          return;
         let token = null;
         try {
           token = localStorage.getItem("token");


### PR DESCRIPTION
## Web Share Target ignored for logged-in users (landing redirect clobbers `/app/edit-recipe/new`)

### Summary

When a recipe URL is shared to RecipeSage via the Android Web Share Target while the user is logged in, the app opens on the recipe list instead of the import/clip screen, so the shared recipe is never clipped.

### Steps to reproduce

`packages/www/src/pages/index.astro` redirects to `/app/edit-recipe/new` (preserving the query) so `edit-recipe.page.ts` `checkAutoClip()`/`autoClip()` can clip the URL.

However, `packages/www/src/components/RootLayout.astro` renders, right after `<slot name="head" />`, an inline `redirectLoggedIn` script that runs `location.replace("/app/")` when an auth token is present. Both inline scripts execute during head parsing in DOM order: `index.astro`'s share redirect (`/app/edit-recipe/new`) runs first, then the `redirectLoggedIn` script's `location.replace("/app/")` runs and overrides it. The last `location.replace` wins, so logged-in users land on `/app/` (the list).

This is confirmed by the asymmetry: logged-out, there is no token, the `redirectLoggedIn` redirect is skipped, and the share correctly reaches the (auth-gated) `/app/edit-recipe/new`; logged-in, it always lands on the list.

### Proposed fix

In the `redirectLoggedIn` inline script, skip the logged-in redirect when incoming Web Share Target params are present, so `index.astro`'s share redirect is preserved.