### PR TITLE
Use two-column recipe tiles on modern iPhones

### DIFF
--- a/packages/frontend/src/app/pages/discover-components/discover/discover.page.html
+++ b/packages/frontend/src/app/pages/discover-components/discover/discover.page.html
@@ -28,7 +28,11 @@
 
     @if (preferences[preferenceKeys.ViewType] === "tiles") {
       <div *uiScroll="let recipeGroup of datasource" class="recipe-group-row">
-        <div class="recipe-group" [class.single-col]="tileColCount === 1">
+        <div
+          class="recipe-group"
+          [class.single-col]="tileColCount === 1"
+          [style.--tile-width]="tileWidth + 'px'"
+        >
           @for (recipe of recipeGroup; track recipe.id) {
             <div class="recipe-card" (click)="openRecipe(recipe)" button>
               @if (recipe.discoverRecipeImages.length) {

--- a/packages/frontend/src/app/pages/discover-components/discover/discover.page.scss
+++ b/packages/frontend/src/app/pages/discover-components/discover/discover.page.scss
@@ -28,11 +28,17 @@
 }
 
 .recipe-group {
+  --tile-width: 200px;
+
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 16px;
   padding: 10px;
+
+  @media only screen and (max-width: 439px) {
+    gap: 10px;
+  }
 
   &.single-col .recipe-card {
     width: 100%;
@@ -40,10 +46,10 @@
 }
 
 .recipe-card {
-  width: 200px;
+  width: var(--tile-width);
   --paragraph-line-height: 1.188rem;
   --content-padding-leeway: 1.5rem;
-  --image-height: 190px;
+  --image-height: min(190px, var(--tile-width));
   --title-height: var(--paragraph-line-height);
   --description-height: calc(var(--paragraph-line-height) * 2);
   --author-height: var(--paragraph-line-height);

--- a/packages/frontend/src/app/pages/discover-components/discover/discover.page.ts
+++ b/packages/frontend/src/app/pages/discover-components/discover/discover.page.ts
@@ -18,6 +18,10 @@ import {
   getDefaultDiscoverLanguages,
   DiscoverLanguageOption,
 } from "../../../utils/discoverLanguages";
+import {
+  calculateRecipeTileLayout,
+  RECIPE_TILE_MAX_WIDTH,
+} from "../../../utils/recipeTileLayout";
 import { SHARED_UI_IMPORTS } from "../../../providers/shared-ui.provider";
 import { RatingComponent } from "../../../components/rating/rating.component";
 import {
@@ -45,8 +49,6 @@ type DiscoverRecipeSummary =
 type DiscoverRecipeAuthor = DiscoverRecipeSummary["author"];
 
 const PAGE_SIZE = 40;
-const TILE_WIDTH = 200;
-const TILE_PADD = 20;
 
 @Component({
   standalone: true,
@@ -95,6 +97,7 @@ export class DiscoverPage {
   recipes: DiscoverRecipeSummary[] = [];
   reachedEnd = false;
   tileColCount = 1;
+  tileWidth = RECIPE_TILE_MAX_WIDTH;
 
   datasource = new Datasource<DiscoverRecipeSummary>({
     get: async (index: number, count: number) => {
@@ -165,12 +168,11 @@ export class DiscoverPage {
     const isSidebarOpen = window.innerWidth >= 1200;
     const sidebarWidth = isSidebarEnabled && isSidebarOpen ? 300 : 0;
     const pageWidth = window.innerWidth - sidebarWidth;
-    const tileColCount = Math.max(
-      Math.floor(pageWidth / (TILE_WIDTH + TILE_PADD)),
-      1,
-    );
-    if (tileColCount !== this.tileColCount) {
-      this.tileColCount = tileColCount;
+    const { columnCount, tileWidth } = calculateRecipeTileLayout(pageWidth);
+    this.tileWidth = tileWidth;
+
+    if (columnCount !== this.tileColCount) {
+      this.tileColCount = columnCount;
       return true;
     }
     return false;

--- a/packages/frontend/src/app/pages/home/home.page.html
+++ b/packages/frontend/src/app/pages/home/home.page.html
@@ -120,7 +120,11 @@
           </div>
         }
         <div *uiScroll="let recipeGroup of datasource" class="recipe-group-row">
-          <div class="recipe-group" [class.single-col]="tileColCount === 1">
+          <div
+            class="recipe-group"
+            [class.single-col]="tileColCount === 1"
+            [style.--tile-width]="tileWidth + 'px'"
+          >
             @for (recipe of recipeGroup; track recipe.id) {
               <div
                 class="recipe-card"

--- a/packages/frontend/src/app/pages/home/home.page.scss
+++ b/packages/frontend/src/app/pages/home/home.page.scss
@@ -66,9 +66,15 @@ ion-badge {
 }
 
 .recipe-group {
+  --tile-width: 200px;
+
   display: flex;
   justify-content: space-around;
   padding: 10px;
+
+  @media only screen and (max-width: 439px) {
+    gap: 10px;
+  }
 
   &.single-col .recipe-card {
     width: 100%;
@@ -98,7 +104,7 @@ ion-badge {
     );
 
     position: relative;
-    width: 200px;
+    width: var(--tile-width);
     height: calc(var(--image-size) + var(--content-height));
     box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.25);
     cursor: pointer;
@@ -111,7 +117,7 @@ ion-badge {
     }
 
     &.showImage {
-      --image-size: 200px;
+      --image-size: var(--tile-width);
     }
     &.showDescription {
       --description-height: var(--paragraph-line-height);

--- a/packages/frontend/src/app/pages/home/home.page.ts
+++ b/packages/frontend/src/app/pages/home/home.page.ts
@@ -30,6 +30,10 @@ import type {
 } from "@recipesage/prisma";
 import { countActiveNutritionRanges } from "../../utils/nutritionFilter";
 import { maybeRequestPersistentStorage } from "../../utils/persistentStorage";
+import {
+  calculateRecipeTileLayout,
+  RECIPE_TILE_MAX_WIDTH,
+} from "../../utils/recipeTileLayout";
 import { SHARED_UI_IMPORTS } from "../../providers/shared-ui.provider";
 import { LogoIconComponent } from "../../components/logo-icon/logo-icon.component";
 import { NullStateComponent } from "../../components/null-state/null-state.component";
@@ -63,9 +67,6 @@ import {
   trashOutline,
 } from "ionicons/icons";
 import { addIcons } from "ionicons";
-
-const TILE_WIDTH = 200;
-const TILE_PADD = 20;
 
 @Component({
   standalone: true,
@@ -150,7 +151,8 @@ export class HomePage implements OnDestroy {
   ratingFilter: (number | null)[] = [];
   nutritionFilter: NutritionFilter = {};
 
-  tileColCount: number = 1;
+  tileColCount = 1;
+  tileWidth = RECIPE_TILE_MAX_WIDTH;
 
   datasource = new Datasource<RecipeSummaryLite>({
     get: async (index: number, count: number) => {
@@ -371,13 +373,11 @@ export class HomePage implements OnDestroy {
     const isSidebarOpen = window.innerWidth >= 1200;
     const sidebarWidth = isSidebarEnabled && isSidebarOpen ? 300 : 0;
     const homePageWidth = window.innerWidth - sidebarWidth;
-    const tileColCount = Math.max(
-      Math.floor(homePageWidth / (TILE_WIDTH + TILE_PADD)),
-      1,
-    );
+    const { columnCount, tileWidth } = calculateRecipeTileLayout(homePageWidth);
+    this.tileWidth = tileWidth;
 
-    if (tileColCount !== this.tileColCount) {
-      this.tileColCount = tileColCount;
+    if (columnCount !== this.tileColCount) {
+      this.tileColCount = columnCount;
 
       // We set to zero since we don't know what the relative position would be now
       this.datasource.settings!.startIndex = 0;

--- a/packages/frontend/src/app/utils/recipeTileLayout.spec.ts
+++ b/packages/frontend/src/app/utils/recipeTileLayout.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { calculateRecipeTileLayout } from "./recipeTileLayout";
+
+describe("calculateRecipeTileLayout", () => {
+  it("uses two columns on recent Pro iPhones", () => {
+    expect(calculateRecipeTileLayout(393)).toEqual({
+      columnCount: 2,
+      tileWidth: 181,
+    });
+    expect(calculateRecipeTileLayout(402)).toEqual({
+      columnCount: 2,
+      tileWidth: 186,
+    });
+  });
+
+  it("keeps narrower screens single-column", () => {
+    expect(calculateRecipeTileLayout(389)).toEqual({
+      columnCount: 1,
+      tileWidth: 200,
+    });
+  });
+
+  it("uses 180 pixel tiles at the two-column breakpoint", () => {
+    expect(calculateRecipeTileLayout(390)).toEqual({
+      columnCount: 2,
+      tileWidth: 180,
+    });
+  });
+
+  it("preserves existing desktop column breakpoints", () => {
+    expect(calculateRecipeTileLayout(659)).toEqual({
+      columnCount: 2,
+      tileWidth: 200,
+    });
+    expect(calculateRecipeTileLayout(660)).toEqual({
+      columnCount: 3,
+      tileWidth: 200,
+    });
+  });
+});

--- a/packages/frontend/src/app/utils/recipeTileLayout.ts
+++ b/packages/frontend/src/app/utils/recipeTileLayout.ts
@@ -1,0 +1,46 @@
+export const RECIPE_TILE_MAX_WIDTH = 200;
+
+const RECIPE_TILE_MIN_WIDTH = 180;
+const RECIPE_TILE_GAP = 10;
+const RECIPE_TILE_ROW_PADDING = 20;
+
+export interface RecipeTileLayout {
+  columnCount: number;
+  tileWidth: number;
+}
+
+export function calculateRecipeTileLayout(pageWidth: number): RecipeTileLayout {
+  const normalizedPageWidth = Math.max(pageWidth, 0);
+
+  // Preserve existing desktop breakpoints while allowing two narrower tiles on phones.
+  const defaultColumnCount = Math.max(
+    Math.floor(
+      normalizedPageWidth / (RECIPE_TILE_MAX_WIDTH + RECIPE_TILE_ROW_PADDING),
+    ),
+    1,
+  );
+  const canFitTwoColumns =
+    normalizedPageWidth >=
+    RECIPE_TILE_ROW_PADDING + RECIPE_TILE_MIN_WIDTH * 2 + RECIPE_TILE_GAP;
+  const columnCount = Math.max(defaultColumnCount, canFitTwoColumns ? 2 : 1);
+
+  if (columnCount === 1) {
+    return {
+      columnCount,
+      tileWidth: RECIPE_TILE_MAX_WIDTH,
+    };
+  }
+
+  const availableTileWidth =
+    normalizedPageWidth -
+    RECIPE_TILE_ROW_PADDING -
+    RECIPE_TILE_GAP * (columnCount - 1);
+
+  return {
+    columnCount,
+    tileWidth: Math.min(
+      RECIPE_TILE_MAX_WIDTH,
+      Math.floor(availableTileWidth / columnCount),
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- allow responsive 180px recipe tiles so 390px+ viewports render two columns
- share tile layout calculations between My Recipes and Discover
- preserve existing desktop breakpoints and single-column behavior on narrower screens

## Testing
- frontend unit tests
- frontend typecheck and Angular lint
- self-hosted frontend build