### PR TITLE
Adjust "My Recipes" page to show 2 columns of recipes instead of 1 when in tile view on mobile

### DIFF
--- a/packages/frontend/src/app/pages/home/home.page.scss
+++ b/packages/frontend/src/app/pages/home/home.page.scss
@@ -66,9 +66,19 @@ ion-badge {
 }
 
 .recipe-group {
+  --tile-width: 200px;
+
   display: flex;
   justify-content: space-around;
   padding: 10px;
+
+  // Keep these bounds aligned with MOBILE_TWO_COLUMN_MIN_WIDTH and the
+  // existing 440px two-column threshold in home.page.ts.
+  @media only screen and (min-width: 375px) and (max-width: 439px) {
+    // Reserve the row's 20px padding plus 12px of slack between the tiles.
+    --tile-width: min(200px, calc((100vw - 32px) / 2));
+    flex-wrap: nowrap;
+  }
 
   &.single-col .recipe-card {
     width: 100%;
@@ -98,7 +108,7 @@ ion-badge {
     );
 
     position: relative;
-    width: 200px;
+    width: var(--tile-width);
     height: calc(var(--image-size) + var(--content-height));
     box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.25);
     cursor: pointer;
@@ -111,7 +121,7 @@ ion-badge {
     }
 
     &.showImage {
-      --image-size: 200px;
+      --image-size: var(--tile-width);
     }
     &.showDescription {
       --description-height: var(--paragraph-line-height);

--- a/packages/frontend/src/app/pages/home/home.page.ts
+++ b/packages/frontend/src/app/pages/home/home.page.ts
@@ -66,6 +66,7 @@ import { addIcons } from "ionicons";
 
 const TILE_WIDTH = 200;
 const TILE_PADD = 20;
+const MOBILE_TWO_COLUMN_MIN_WIDTH = 375;
 
 @Component({
   standalone: true,
@@ -371,9 +372,11 @@ export class HomePage implements OnDestroy {
     const isSidebarOpen = window.innerWidth >= 1200;
     const sidebarWidth = isSidebarEnabled && isSidebarOpen ? 300 : 0;
     const homePageWidth = window.innerWidth - sidebarWidth;
+    const minimumColumnCount =
+      homePageWidth >= MOBILE_TWO_COLUMN_MIN_WIDTH ? 2 : 1;
     const tileColCount = Math.max(
       Math.floor(homePageWidth / (TILE_WIDTH + TILE_PADD)),
-      1,
+      minimumColumnCount,
     );
 
     if (tileColCount !== this.tileColCount) {


### PR DESCRIPTION
Allow My Recipes tiles to shrink between 375px and 439px so recent iPhones render two columns while preserving desktop sizing.

Before:
<img width="603" height="1311" alt="20260710_025948000_iOS" src="https://github.com/user-attachments/assets/8dd8c8a3-5a60-4aa9-9a18-7a12af24eb2c" />

After:
<img width="792" height="1051" alt="sage_with_change" src="https://github.com/user-attachments/assets/6a7df61b-e3f4-4756-b1f6-709aec527474" />
